### PR TITLE
test: add CI, tree + truncate coverage; dedupe truncate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # rsvg-convert lets the raster test exercise real SVG -> PNG conversion
+      # instead of skipping its body.
+      - name: Install SVG converter (rsvg-convert)
+        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
+
+      - name: Set up Neovim nightly
+        uses: rhysd/action-setup-vim@v1
+        id: nvim
+        with:
+          neovim: true
+          version: nightly
+
+      - name: Run headless test suite
+        run: SVGTREE_NVIM='${{ steps.nvim.outputs.executable }}' bash scripts/test.sh

--- a/lua/svgtree/adapters/snacks.lua
+++ b/lua/svgtree/adapters/snacks.lua
@@ -29,6 +29,7 @@ local config = require('svgtree.config')
 local engine = require('svgtree.engine')
 local capability = require('svgtree.capability')
 local icons = require('svgtree.icons')
+local text = require('svgtree.text')
 
 local M = {}
 
@@ -74,28 +75,6 @@ local attached = setmetatable({}, { __mode = 'k' })
 -- holds its lines blank until this flips, so the explorer's first visible
 -- content already has icons (no text-then-icon pop). Keyed weakly by picker.
 local ready = setmetatable({}, { __mode = 'k' })
-
--- Trim a string to a display-cell budget, appending '…' if it overflows
--- (VSCode-style end-truncation). Width-aware, so multibyte names behave.
-local function truncate(s, budget)
-  if budget <= 0 then
-    return ''
-  end
-  if vim.fn.strdisplaywidth(s) <= budget then
-    return s
-  end
-  if budget == 1 then
-    return '…'
-  end
-  local target = budget - 1 -- room for the ellipsis (1 cell)
-  local n = vim.fn.strchars(s)
-  local out = s
-  while n > 0 and vim.fn.strdisplaywidth(out) > target do
-    n = n - 1
-    out = vim.fn.strcharpart(s, 0, n)
-  end
-  return out .. '…'
-end
 
 ---@param item svgtree.snacks.Item
 ---@return string? stem
@@ -186,7 +165,7 @@ function M.format(item, picker)
       el[1] = ''
       el.field = nil
       el.resolve = function(avail)
-        return { { truncate(name, math.max(avail - 1, 1)), hl, field = 'file' } }
+        return { { text.truncate(name, math.max(avail - 1, 1)), hl, field = 'file' } }
       end
       break
     end

--- a/lua/svgtree/render.lua
+++ b/lua/svgtree/render.lua
@@ -10,6 +10,7 @@ local capability = require('svgtree.capability')
 local icons = require('svgtree.icons')
 local Tree = require('svgtree.tree')
 local winlock = require('svgtree.winlock')
+local text = require('svgtree.text')
 
 local M = {}
 
@@ -19,28 +20,6 @@ local view = nil
 -- byte column (1-indexed) where the icon sits for a given depth
 local function icon_col(depth)
   return depth * config.options.indent + 1
-end
-
--- Trim a string to a display-cell budget, appending '…' if it overflows
--- (VSCode-style). Width-aware, so multibyte names behave.
-local function truncate(s, budget)
-  if budget <= 0 then
-    return ''
-  end
-  if vim.fn.strdisplaywidth(s) <= budget then
-    return s
-  end
-  if budget == 1 then
-    return '…'
-  end
-  local target = budget - 1 -- room for the ellipsis (1 cell)
-  local n = vim.fn.strchars(s)
-  local out = s
-  while n > 0 and vim.fn.strdisplaywidth(out) > target do
-    n = n - 1
-    out = vim.fn.strcharpart(s, 0, n)
-  end
-  return out .. '…'
 end
 
 -- Build buffer text from the flattened node list, truncating names that would
@@ -70,7 +49,7 @@ local function render_lines()
     local suffix = node.kind == 'dir' and '/' or ''
     -- Budget the name to what's left of the window (1-cell right margin).
     local budget = width - vim.fn.strdisplaywidth(prefix) - 1
-    lines[#lines + 1] = prefix .. truncate(node.name .. suffix, budget)
+    lines[#lines + 1] = prefix .. text.truncate(node.name .. suffix, budget)
   end
   vim.bo[view.buf].modifiable = true
   vim.api.nvim_buf_set_lines(view.buf, 0, -1, false, lines)

--- a/lua/svgtree/text.lua
+++ b/lua/svgtree/text.lua
@@ -1,0 +1,32 @@
+-- Shared text helpers for the tree view and the host adapters. Kept in one
+-- place so the view (render.lua) and the snacks/neo-tree adapters truncate
+-- names identically.
+
+local M = {}
+
+-- Trim a string to a display-cell budget, appending '…' if it overflows
+-- (VSCode-style end-truncation). Width-aware, so multibyte names behave.
+---@param s string
+---@param budget integer display cells available
+---@return string
+function M.truncate(s, budget)
+  if budget <= 0 then
+    return ''
+  end
+  if vim.fn.strdisplaywidth(s) <= budget then
+    return s
+  end
+  if budget == 1 then
+    return '…'
+  end
+  local target = budget - 1 -- room for the ellipsis (1 cell)
+  local n = vim.fn.strchars(s)
+  local out = s
+  while n > 0 and vim.fn.strdisplaywidth(out) > target do
+    n = n - 1
+    out = vim.fn.strcharpart(s, 0, n)
+  end
+  return out .. '…'
+end
+
+return M

--- a/scripts/test-tree.lua
+++ b/scripts/test-tree.lua
@@ -1,0 +1,70 @@
+-- Headless checks for svgtree.tree (directory model: sort, flatten, toggle).
+-- Builds a temp fixture dir, so it touches the filesystem but stays
+-- deterministic. Run via scripts/test.sh.
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+require('svgtree.config').setup({})
+local Tree = require('svgtree.tree')
+
+local fails = 0
+local function check(c, m)
+  if c then print('  ok  ' .. m) else print('  FAIL ' .. m); fails = fails + 1 end
+end
+
+-- ---- fixture: dirs + files + hidden entries, mixed case ----
+local root = vim.fn.tempname()
+vim.fn.mkdir(root .. '/alpha', 'p')
+vim.fn.mkdir(root .. '/Beta', 'p') -- capital B: exercises case-insensitive sort
+vim.fn.mkdir(root .. '/.hidden_dir', 'p')
+vim.fn.writefile({}, root .. '/alpha/nested.txt')
+vim.fn.writefile({}, root .. '/apple.txt')
+vim.fn.writefile({}, root .. '/zebra.txt')
+vim.fn.writefile({}, root .. '/.secret')
+
+local t = Tree.new(root)
+
+-- ---- flatten at root: dirs first, case-insensitive alpha; hidden excluded ----
+local nodes = t:flatten()
+local names = vim.tbl_map(function(n)
+  return n.name
+end, nodes)
+check(#nodes == 4, 'root has 4 visible entries (hidden excluded), got ' .. #nodes)
+check(
+  table.concat(names, ',') == 'alpha,Beta,apple.txt,zebra.txt',
+  'dirs-first then case-insensitive alpha: ' .. table.concat(names, ',')
+)
+check(nodes[1].kind == 'dir' and nodes[2].kind == 'dir', 'first two entries are dirs')
+check(nodes[3].kind == 'file' and nodes[4].kind == 'file', 'last two entries are files')
+check(nodes[1].depth == 0, 'top-level depth is 0')
+
+local leaked_hidden = false
+for _, n in ipairs(nodes) do
+  if n.name:sub(1, 1) == '.' then
+    leaked_hidden = true
+  end
+end
+check(not leaked_hidden, 'dotfiles/dirs excluded by default')
+
+-- ---- toggle expand: child appears at depth+1 immediately after its dir ----
+local alpha = nodes[1].path
+check(t:is_expanded(alpha) == false, 'alpha starts collapsed')
+t:toggle(alpha)
+check(t:is_expanded(alpha) == true, 'alpha expanded after toggle')
+
+local exp = t:flatten()
+local en = vim.tbl_map(function(n)
+  return n.name
+end, exp)
+check(
+  table.concat(en, ',') == 'alpha,nested.txt,Beta,apple.txt,zebra.txt',
+  'expanded child nests under alpha at depth 1: ' .. table.concat(en, ',')
+)
+check(exp[2].name == 'nested.txt' and exp[2].depth == 1, 'nested.txt is depth 1')
+
+-- ---- toggle again collapses back ----
+t:toggle(alpha)
+check(t:is_expanded(alpha) == false, 'alpha collapsed after second toggle')
+check(#t:flatten() == 4, 'collapsed back to 4 entries')
+
+vim.fn.delete(root, 'rf')
+
+if fails > 0 then print('FAILED: ' .. fails); os.exit(1) else print('test-tree: ALL PASS') end

--- a/scripts/test-truncate.lua
+++ b/scripts/test-truncate.lua
@@ -1,0 +1,40 @@
+-- Headless checks for svgtree.text.truncate (width-aware end-truncation).
+-- Run via scripts/test.sh.
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+local t = require('svgtree.text').truncate
+
+local fails = 0
+local function check(c, m)
+  if c then print('  ok  ' .. m) else print('  FAIL ' .. m); fails = fails + 1 end
+end
+
+-- ---- degenerate budgets ----
+check(t('hello', 0) == '', 'budget 0 -> empty')
+check(t('hello', -3) == '', 'negative budget -> empty')
+check(t('', 5) == '', 'empty string -> empty')
+
+-- ---- no truncation needed ----
+check(t('hello', 5) == 'hello', 'exact fit -> unchanged')
+check(t('hi', 5) == 'hi', 'shorter than budget -> unchanged')
+
+-- ---- budget 1 is ellipsis-only when it overflows ----
+check(t('hello', 1) == '…', 'budget 1 + overflow -> ellipsis only')
+
+-- ---- ascii overflow: head + ellipsis, fits the budget ----
+local r = t('hello', 3)
+check(r == 'he…', 'ascii overflow -> he…')
+check(vim.fn.strdisplaywidth(r) <= 3, 'ascii result fits budget')
+
+-- ---- width-aware: single-width multibyte (é) ----
+check(t('café', 4) == 'café', 'multibyte exact fit unchanged')
+local r2 = t('café', 3)
+check(vim.fn.strdisplaywidth(r2) <= 3, 'multibyte overflow fits budget')
+check(r2:sub(-3) == '…', 'multibyte overflow ends with ellipsis')
+
+-- ---- width-aware: double-width (CJK, 2 cells each) ----
+check(t('世界', 4) == '世界', 'double-width exact fit unchanged')
+local r3 = t('世界', 3)
+check(r3 == '世…', 'double-width overflow -> 世…')
+check(vim.fn.strdisplaywidth(r3) <= 3, 'double-width result fits budget')
+
+if fails > 0 then print('FAILED: ' .. fails); os.exit(1) else print('test-truncate: ALL PASS') end

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,7 @@ fi
 
 cd "$(dirname "$0")/.." || exit 2
 
-scripts=(scripts/test-capability.lua scripts/test-winlock.lua scripts/test-raster.lua scripts/test-pack.lua)
+scripts=(scripts/test-capability.lua scripts/test-winlock.lua scripts/test-raster.lua scripts/test-pack.lua scripts/test-tree.lua scripts/test-truncate.lua)
 fail=0
 for s in "${scripts[@]}"; do
   [ -f "$s" ] || continue        # a script is added by the Task that introduces it


### PR DESCRIPTION
## What

Strengthens the test story for the repo (per the testing assessment).

- **Dedupe + test `truncate`.** `render.lua` and the snacks adapter held byte-identical copies of the width-aware `truncate()`. Extracted to a new `svgtree.text` module (DRY) and tested directly — degenerate budgets (`<=0`, `==1`), exact-fit, and width-aware multibyte (`café`) and double-width CJK (`世界`) cases.
- **`test-tree.lua`.** New coverage for the previously-untested directory model over a temp fixture: dirs-first / case-insensitive sort, `flatten` of the expanded subtree, `toggle`/`is_expanded`, and hidden-entry exclusion.
- Both new tests are registered in `scripts/test.sh`.

## Pending: CI workflow

A `.github/workflows/test.yml` (run `scripts/test.sh` on nvim-nightly for every PR) is part of this change but **couldn't be pushed** — the git token lacks the `workflow` OAuth scope, and the API token can't write to this repo. It'll be added to this branch once that's resolved (see PR discussion).

## Verification

`bash scripts/test.sh` → **SUITE PASSED** (all six scripts), and `lua-language-server --check` is clean after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)