### PR TITLE
Document the bufferline adapter wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ require("svgtree").setup({
 })
 ```
 
-## Use the icon engine in snacks.nvim / neo-tree
+## Use the icon engine in snacks.nvim / neo-tree / bufferline
 
-svgtree's icon machinery is a **host-agnostic engine** you can attach to an existing explorer to get real SVG icons there — no need to switch to svgtree's own tree. Call `require("svgtree").setup({})` once, then wire an adapter.
+svgtree's icon machinery is a **host-agnostic engine** you can attach to an existing explorer — or the bufferline tabline — to get real SVG icons there, no need to switch to svgtree's own tree. Call `require("svgtree").setup({})` once, then wire an adapter.
 
 ### snacks.nvim explorer
 
@@ -163,7 +163,28 @@ require("neo-tree").setup({
 -- require("svgtree.adapters.neotree").setup({ col_offset = 1 })
 ```
 
-Both require the same prerequisites as the main tree. When they're unavailable, the adapters no-op and the host renders as usual.
+### bufferline.nvim (tabs)
+
+Show each buffer's icon on its tab, matching the explorer. The tabline isn't a buffer, so this adapter doesn't use the overlay engine — it returns the icon as Kitty placeholder text + a highlight whose foreground colour carries the image id, via bufferline's `get_element_icon` hook.
+
+```lua
+-- lua/plugins/bufferline.lua
+require("svgtree.adapters.bufferline").setup() -- once; pre-warms tab icons
+opts = {
+  options = {
+    -- Required: the image id rides in the icon highlight's fg, so color_icons
+    -- must stay on (color_icons = false forces fg = NONE and breaks the icon).
+    color_icons = true,
+    get_element_icon = function(element)
+      -- Returns nil on stable nvim / non-graphics terminals, so bufferline
+      -- falls back to its usual glyph (e.g. mini.icons / nvim-web-devicons).
+      return require("svgtree.adapters.bufferline").get_element_icon(element)
+    end,
+  },
+}
+```
+
+All three require the same prerequisites as the main tree. When they're unavailable, the adapters no-op and the host renders as usual.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

The last change gave the bufferline tabs the *ability* to show real SVG icons — but shipped it like a piece of flat-pack furniture with no assembly leaflet in the box. The parts were all there; nobody told you which screws to turn. This PR is that leaflet: a short snippet you paste into your config to switch tab icons on, so they match the file explorer without anyone having to read the source to reverse-engineer the wiring.

It also calls out the one easy-to-trip-over catch — there's a switch that has to stay flipped on, or the icons quietly stop working (like a lamp that only lights up if you leave the wall switch on, however much you click the one on the cord).

## TLDR for developers

Docs-only. In the "Use the icon engine in …" section of `README.md`:

- Folded **bufferline** into the section heading and intro alongside snacks / neo-tree.
- New **`bufferline.nvim (tabs)`** subsection with the `get_element_icon` wiring and a one-line note that it returns `nil` on non-graphics terminals (so bufferline falls back to its usual glyph).
- Called out the **`color_icons = true`** requirement explicitly — the image id rides in the icon highlight's `fg`, so `color_icons = false` forces `fg = NONE` and breaks the icon. This is the non-obvious bit and the most likely support question.

Left "How it works" unchanged: it describes the extmark-overlay engine, which the bufferline adapter deliberately doesn't use (the new subsection explains the placeholder-text-in-the-tabline approach instead), so it's still accurate.

## Evidence

No code paths changed — README only. The wiring documented is exactly what's verified by `scripts/test-bufferline-adapter.lua` (merged in the previous PR): `get_element_icon` returning placeholder text + an `fg`-encoded highlight, and `nil` on the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)